### PR TITLE
removed double quotes in JS files, fixed CURL responses

### DIFF
--- a/snippets/http.md
+++ b/snippets/http.md
@@ -8,18 +8,18 @@ OData-MaxVersion: 4.0
 Response:
 ```HTTP
 HTTP/1.1 200 OK
- 
+
 Content-Length: 1007
 Content-Type: application/json; odata.metadata=minimal
 OData-Version: 4.0
- 
+
 {
     "@odata.context": "http://services.odata.org/V4/(S(a2k31bgwiyejn2j2iiybvq4p))/TripPinServiceRW/$metadata#People",
     "@odata.nextLink": "http://services.odata.org/V4/(S(a2k31bgwiyejn2j2iiybvq4p))/TripPinServiceRW/People?%24skiptoken=8",
     "value": [
         {
             "@odata.id": "http://services.odata.org/V4/(S(a2k31bgwiyejn2j2iiybvq4p))/TripPinServiceRW/People('russellwhyte')",
-            "@odata.etag": "W/"08D1D5BD423E5158"",
+            "@odata.etag": "W/\"08D1D5BD423E5158\"",
             "@odata.editLink": "http://services.odata.org/V4/(S(a2k31bgwiyejn2j2iiybvq4p))/TripPinServiceRW/People('russellwhyte')",
             "UserName": "russellwhyte",
             "FirstName": "Russell",
@@ -45,7 +45,7 @@ OData-Version: 4.0
         },
         {
             "@odata.id": "http://services.odata.org/V4/(S(a2k31bgwiyejn2j2iiybvq4p))/TripPinServiceRW/People('scottketchum')",
-            "@odata.etag": "W/"08D1D5BD423E5158"",
+            "@odata.etag": "W/\"08D1D5BD423E5158\"",
             "@odata.editLink": "http://services.odata.org/V4/(S(a2k31bgwiyejn2j2iiybvq4p))/TripPinServiceRW/People('scottketchum')",
             "UserName": "scottketchum",
             "FirstName": "Scott",
@@ -68,7 +68,7 @@ OData-Version: 4.0
         },
         {
             "@odata.id": "http://services.odata.org/V4/(S(a2k31bgwiyejn2j2iiybvq4p))/TripPinServiceRW/People('ronaldmundy')",
-            "@odata.etag": "W/"08D1D5BD423E5158"",
+            "@odata.etag": "W/\"08D1D5BD423E5158\"",
             "@odata.editLink": "http://services.odata.org/V4/(S(a2k31bgwiyejn2j2iiybvq4p))/TripPinServiceRW/People('ronaldmundy')",
             "UserName": "ronaldmundy",
             "FirstName": "Ronald",
@@ -83,7 +83,7 @@ OData-Version: 4.0
         },
         {
             "@odata.id": "http://services.odata.org/V4/(S(a2k31bgwiyejn2j2iiybvq4p))/TripPinServiceRW/People('javieralfred')",
-            "@odata.etag": "W/"08D1D5BD423E5158"",
+            "@odata.etag": "W/\"08D1D5BD423E5158\"",
             "@odata.editLink": "http://services.odata.org/V4/(S(a2k31bgwiyejn2j2iiybvq4p))/TripPinServiceRW/People('javieralfred')",
             "UserName": "javieralfred",
             "FirstName": "Javier",
@@ -107,7 +107,7 @@ OData-Version: 4.0
         },
         {
             "@odata.id": "http://services.odata.org/V4/(S(a2k31bgwiyejn2j2iiybvq4p))/TripPinServiceRW/People('willieashmore')",
-            "@odata.etag": "W/"08D1D5BD423E5158"",
+            "@odata.etag": "W/\"08D1D5BD423E5158\"",
             "@odata.editLink": "http://services.odata.org/V4/(S(a2k31bgwiyejn2j2iiybvq4p))/TripPinServiceRW/People('willieashmore')",
             "UserName": "willieashmore",
             "FirstName": "Willie",
@@ -122,7 +122,7 @@ OData-Version: 4.0
         },
         {
             "@odata.id": "http://services.odata.org/V4/(S(a2k31bgwiyejn2j2iiybvq4p))/TripPinServiceRW/People('vincentcalabrese')",
-            "@odata.etag": "W/"08D1D5BD423E5158"",
+            "@odata.etag": "W/\"08D1D5BD423E5158\"",
             "@odata.editLink": "http://services.odata.org/V4/(S(a2k31bgwiyejn2j2iiybvq4p))/TripPinServiceRW/People('vincentcalabrese')",
             "UserName": "vincentcalabrese",
             "FirstName": "Vincent",
@@ -146,7 +146,7 @@ OData-Version: 4.0
         },
         {
             "@odata.id": "http://services.odata.org/V4/(S(a2k31bgwiyejn2j2iiybvq4p))/TripPinServiceRW/People('clydeguess')",
-            "@odata.etag": "W/"08D1D5BD423E5158"",
+            "@odata.etag": "W/\"08D1D5BD423E5158\"",
             "@odata.editLink": "http://services.odata.org/V4/(S(a2k31bgwiyejn2j2iiybvq4p))/TripPinServiceRW/People('clydeguess')",
             "UserName": "clydeguess",
             "FirstName": "Clyde",
@@ -160,7 +160,7 @@ OData-Version: 4.0
         },
         {
             "@odata.id": "http://services.odata.org/V4/(S(a2k31bgwiyejn2j2iiybvq4p))/TripPinServiceRW/People('keithpinckney')",
-            "@odata.etag": "W/"08D1D5BD423E5158"",
+            "@odata.etag": "W/\"08D1D5BD423E5158\"",
             "@odata.editLink": "http://services.odata.org/V4/(S(a2k31bgwiyejn2j2iiybvq4p))/TripPinServiceRW/People('keithpinckney')",
             "UserName": "keithpinckney",
             "FirstName": "Keith",
@@ -187,16 +187,16 @@ OData-MaxVersion: 4.0
 Response:
 ```HTTP
 HTTP/1.1 200 OK
- 
+
 Content-Length: 482
 Content-Type: application/json; odata.metadata=minimal
 ETag: W/"08D1D5BE987DE78B"
 OData-Version: 4.0
- 
+
 {
     "@odata.context": "http://services.odata.org/V4/(S(ak3ckilwx5ajembdktfunu0v))/TripPinServiceRW/$metadata#People/$entity",
     "@odata.id": "http://services.odata.org/V4/(S(ak3ckilwx5ajembdktfunu0v))/TripPinServiceRW/People('russellwhyte')",
-    "@odata.etag": "W/"08D1D5BE987DE78B"",
+    "@odata.etag": "W/\"08D1D5BE987DE78B\"",
     "@odata.editLink": "http://services.odata.org/V4/(S(ak3ckilwx5ajembdktfunu0v))/TripPinServiceRW/People('russellwhyte')",
     "UserName": "russellwhyte",
     "FirstName": "Russell",
@@ -234,24 +234,24 @@ var people =
 Response:
 ```HTTP
 HTTP/1.1 200 OK
- 
+
 Content-Length: 367
 Content-Type: application/json; odata.metadata=minimal
 OData-Version: 4.0
- 
+
 {
     "@odata.context": "http://services.odata.org/V4/(S(cn0zbczilimhpqbgnre0usaz))/TripPinServiceRW/$metadata#People(FirstName,LastName)",
     "value": [
         {
             "@odata.id": "http://services.odata.org/V4/(S(cn0zbczilimhpqbgnre0usaz))/TripPinServiceRW/People('scottketchum')",
-            "@odata.etag": "W/"08D1D5BEF93F01A6"",
+            "@odata.etag": "W/\"08D1D5BEF93F01A6\"",
             "@odata.editLink": "http://services.odata.org/V4/(S(cn0zbczilimhpqbgnre0usaz))/TripPinServiceRW/People('scottketchum')",
             "FirstName": "Scott",
             "LastName": "Ketchum"
         },
         {
             "@odata.id": "http://services.odata.org/V4/(S(cn0zbczilimhpqbgnre0usaz))/TripPinServiceRW/People('ronaldmundy')",
-            "@odata.etag": "W/"08D1D5BEF93F01A6"",
+            "@odata.etag": "W/\"08D1D5BEF93F01A6\"",
             "@odata.editLink": "http://services.odata.org/V4/(S(cn0zbczilimhpqbgnre0usaz))/TripPinServiceRW/People('ronaldmundy')",
             "FirstName": "Ronald",
             "LastName": "Mundy"
@@ -268,7 +268,7 @@ OData-Version: 4.0
 OData-MaxVersion: 4.0
 Content-Length: 428
 Content-Type: application/json
- 
+
 {
     "UserName":"lewisblack",
     "FirstName":"Lewis",
@@ -293,7 +293,7 @@ Content-Type: application/json
 Response:
 ```HTTP
 HTTP/1.1 201 Created
- 
+
 Content-Length: 652
 Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
 ETag: W/"08D1D3800FC572E3"
@@ -309,7 +309,7 @@ OData-Version: 4.0
 OData-MaxVersion: 4.0
 Content-Length: 123
 Content-Type: application/json
- 
+
 {
     "@odata.id":"http://services.odata.org/V4/(S(34wtn2c0hkuk5ekg0pjr513b))/TripPinServiceRW/People('russellwhyte')/Trips(0)"
 }
@@ -331,17 +331,17 @@ OData-MaxVersion: 4.0
 Response:
 ```HTTP
 HTTP/1.1 200 OK
- 
+
 Content-Length: 582
 Content-Type: application/json; odata.metadata=minimal
 OData-Version: 4.0
- 
+
 {
     "@odata.context": "http://services.odata.org/V4/(S(34wtn2c0hkuk5ekg0pjr513b))/TripPinServiceRW/$metadata#People",
     "value": [
         {
             "@odata.id": "http://services.odata.org/V4/(S(34wtn2c0hkuk5ekg0pjr513b))/TripPinServiceRW/People('russellwhyte')",
-            "@odata.etag": "W/"08D1D5BFB48CE017"",
+            "@odata.etag": "W/\"08D1D5BFB48CE017\"",
             "@odata.editLink": "http://services.odata.org/V4/(S(34wtn2c0hkuk5ekg0pjr513b))/TripPinServiceRW/People('russellwhyte')",
             "UserName": "russellwhyte",
             "FirstName": "Russell",
@@ -367,7 +367,7 @@ OData-Version: 4.0
         },
         {
             "@odata.id": "http://services.odata.org/V4/(S(34wtn2c0hkuk5ekg0pjr513b))/TripPinServiceRW/People('scottketchum')",
-            "@odata.etag": "W/"08D1D5BFB48CE017"",
+            "@odata.etag": "W/\"08D1D5BFB48CE017\"",
             "@odata.editLink": "http://services.odata.org/V4/(S(34wtn2c0hkuk5ekg0pjr513b))/TripPinServiceRW/People('scottketchum')",
             "UserName": "scottketchum",
             "FirstName": "Scott",

--- a/snippets/nodejs.md
+++ b/snippets/nodejs.md
@@ -3,13 +3,13 @@ Download and install the Node.js platform from [nodejs.org] then run the snippet
 
 # Step 1: Requesting resources
 ```js
-var http = require("http");
-var serviceRoot = "http://services.odata.org/v4/TripPinServiceRW/";
+var http = require('http');
+var serviceRoot = 'http://services.odata.org/v4/TripPinServiceRW/';
 
-getURL(serviceRoot + "/People");
+getURL(serviceRoot + '/People');
 
 function getURL(url) {
-    var body = "";
+    var body = '';
     http.get(url, function (response) {
         response.on('data', function (chunk) {
             body+=chunk;
@@ -19,19 +19,19 @@ function getURL(url) {
         });
 
     }).on('error', function(e) {
-        console.log("ERROR: " + e.message);
+        console.log('ERROR: ' + e.message);
     });
 }
 ```
 # Step 2: Requesting an individual resource
 ```js
-var http = require("http");
-var serviceRoot = "http://services.odata.org/v4/TripPinServiceRW/";
+var http = require('http');
+var serviceRoot = 'http://services.odata.org/v4/TripPinServiceRW/';
 
-getURL(serviceRoot + "People('russellwhyte')");
+getURL(serviceRoot + 'People(\'russellwhyte\')');
 
 function getURL(url) {
-    var body = "";
+    var body = '';
     http.get(url, function (response) {
         response.on('data', function (chunk) {
             body+=chunk;
@@ -41,19 +41,19 @@ function getURL(url) {
         });
 
     }).on('error', function(e) {
-        console.log("ERROR: " + e.message);
+        console.log('ERROR: ' + e.message);
     });
 }
 ```
 # Step 3: Queries
 ```js
-var http = require("http");
-var serviceRoot = "http://services.odata.org/v4/TripPinServiceRW/";
+var http = require('http');
+var serviceRoot = 'http://services.odata.org/v4/TripPinServiceRW/';
 
-getURL(serviceRoot + "People?$top=2 & $select=FirstName, LastName & $filter=Trips/any(d:d/Budget gt 3000)");
+getURL(serviceRoot + 'People?$top=2 & $select=FirstName, LastName & $filter=Trips/any(d:d/Budget gt 3000)');
 
 function getURL(url) {
-    var body = "";
+    var body = '';
     http.get(url, function (response) {
         response.on('data', function (chunk) {
             body+=chunk;
@@ -63,41 +63,41 @@ function getURL(url) {
         });
 
     }).on('error', function(e) {
-        console.log("ERROR: " + e.message);
+        console.log('ERROR: ' + e.message);
     });
 }
 ```
 # Step 4: Creating a new resource
 ```js
-var http = require("http");
-var serviceHost = "services.odata.org";
-var servicePath = "/v4/TripPinServiceRW/";
+var http = require('http');
+var serviceHost = 'services.odata.org';
+var servicePath = '/v4/TripPinServiceRW/';
 
 var newPerson = {
-    UserName:"lewisblack",
-    FirstName:"Lewis",
-    LastName:"Black",
+    UserName:'lewisblack',
+    FirstName:'Lewis',
+    LastName:'Black',
     Emails:[
-        "lewisblack@example.com"
+        'lewisblack@example.com'
     ],
     AddressInfo:[
         {
-            Address: "187 Suffolk Ln.",
+            Address: '187 Suffolk Ln.',
             City: {
-                CountryRegion: "United States",
-                Name: "Boise",
-                Region: "ID"
+                CountryRegion: 'United States',
+                Name: 'Boise',
+                Region: 'ID'
             }
         }
     ],
-    Gender: "Male"
+    Gender: 'Male'
 };
 
 var postData = JSON.stringify(newPerson);
 
 var options = {
     hostname: serviceHost,
-    path: servicePath + "People",
+    path: servicePath + 'People',
     port: 80,
     method: 'POST',
     headers: {
@@ -109,7 +109,7 @@ var options = {
 };
 
 var req = http.request(options, function(res) {
-    var body = "";
+    var body = '';
     res.on('data', function (chunk) {
         body += chunk;
     });
@@ -127,17 +127,17 @@ req.end();
 ```
 # Step 5: Relating resources
 ```js
-var http = require("http");
-var serviceHost = "services.odata.org";
-var servicePath = "/v4/TripPinServiceRW/";
+var http = require('http');
+var serviceHost = 'services.odata.org';
+var servicePath = '/v4/TripPinServiceRW/';
 
 var postData = JSON.stringify({
-    "@odata.id": "http://services.odata.org/V4/TripPinServiceRW/People('russellwhyte')/Trips(0)"
+    '@odata.id': 'http://services.odata.org/V4/TripPinServiceRW/People(\'russellwhyte\')/Trips(0)'
 });
 
 var options = {
     hostname: serviceHost,
-    path: servicePath + "People('lewisblack')/Trips/$ref",
+    path: servicePath + 'People(\'lewisblack\')/Trips/$ref',
     port: 80,
     method: 'POST',
     headers: {
@@ -149,7 +149,7 @@ var options = {
 };
 
 var req = http.request(options, function(res) {
-    var body = "";
+    var body = '';
     res.on('data', function (chunk) {
         body += chunk;
     });
@@ -167,13 +167,13 @@ req.end();
 ```
 # Step 6: Invoking a function
 ```js
-var http = require("http");
-var serviceRoot = "http://services.odata.org/v4/TripPinServiceRW/";
+var http = require('http');
+var serviceRoot = 'http://services.odata.org/v4/TripPinServiceRW/';
 
-getURL(serviceRoot + "People('russellwhyte')/Trips(0)/Microsoft.OData.SampleService.Models.TripPin.GetInvolvedPeople()");
+getURL(serviceRoot + 'People(\'russellwhyte\')/Trips(0)/Microsoft.OData.SampleService.Models.TripPin.GetInvolvedPeople()');
 
 function getURL(url) {
-    var body = "";
+    var body = '';
     http.get(url, function (response) {
         response.on('data', function (chunk) {
             body+=chunk;
@@ -183,7 +183,7 @@ function getURL(url) {
         });
 
     }).on('error', function(e) {
-        console.log("ERROR: " + e.message);
+        console.log('ERROR: ' + e.message);
     });
 }
 ```

--- a/snippets/olingo-odata-client-for-javascript.md
+++ b/snippets/olingo-odata-client-for-javascript.md
@@ -1,162 +1,162 @@
 # Step 0: Download the library file
 Download the Olingo OData Client for JavaScript from [olingo.apache.org](http://olingo.apache.org/doc/javascript/download.html). Then add the reference below
 ```html
-<script src="odatajs-4.0.0-beta-01.min.js" type="text/javascript"></script>
+<script src='odatajs-4.0.0-beta-01.min.js' type='text/javascript'></script>
 ```
 
 # Step 1: Requesting resources
 ```js
-var serviceRoot = "http://services.odata.org/V4/TripPinServiceRW/";
-var headers = { "Content-Type": "application/json", Accept: "application/json" };
+var serviceRoot = 'http://services.odata.org/V4/TripPinServiceRW/';
+var headers = { 'Content-Type': 'application/json', Accept: 'application/json' };
 var request = {
-    requestUri: serviceRoot + "People",
-    method: "GET",
+    requestUri: serviceRoot + 'People',
+    method: 'GET',
     headers: headers,
     data: null
 };
- 
+
 odatajs.oData.request(
-    request, 
+    request,
     function (data, response) {
         var people = data.value;
- 
-    }, 
+
+    },
     function (err) {
-        alert("Fail: " + err.Message);
+        alert('Fail: ' + err.Message);
     }
 );
 
 ```
 # Step 2: Requesting an individual resource
 ```js
-var serviceRoot = "http://services.odata.org/V4/TripPinServiceRW/";
-var headers = { "Content-Type": "application/json", Accept: "application/json" };
+var serviceRoot = 'http://services.odata.org/V4/TripPinServiceRW/';
+var headers = { 'Content-Type': 'application/json', Accept: 'application/json' };
 var request = {
-    requestUri: serviceRoot + "People('russellwhyte')",
-    method: "GET",
+    requestUri: serviceRoot + 'People(\'russellwhyte\')',
+    method: 'GET',
     headers: headers,
     data: null
 };
- 
+
 odatajs.oData.request(
     request,
     function (data, response) {
         var russell = data;
- 
+
     },
     function (err) {
-        alert("Fail: " + err.Message);
+        alert('Fail: ' + err.Message);
     }
 );
 ```
 # Step 3: Queries
 ```js
-var serviceRoot = "http://services.odata.org/V4/TripPinServiceRW/";
-var headers = { "Content-Type": "application/json", Accept: "application/json" };
+var serviceRoot = 'http://services.odata.org/V4/TripPinServiceRW/';
+var headers = { 'Content-Type': 'application/json', Accept: 'application/json' };
 var request = {
-    requestUri: serviceRoot + "People?$top=2&$filter=Trips/any(d:d/Budget gt 3000)",
-    method: "GET",
+    requestUri: serviceRoot + 'People?$top=2&$filter=Trips/any(d:d/Budget gt 3000)',
+    method: 'GET',
     headers: headers,
     data: null
 };
- 
+
 odatajs.oData.request(
     request,
     function (data, response) {
         var filtedPeople = data.value;
         var FirstName = filtedPeople[0].FirstName;
- 
+
     },
     function (err) {
-        alert("Fail: " + err.Message);
+        alert('Fail: ' + err.Message);
     }
 );
 ```
 # Step 4: Creating a new resource
 ```js
-var serviceRoot = "http://services.odata.org/V4/(S(34wtn2c0hkuk5ekg0pjr513b))/TripPinServiceRW/";
-var headers = { "Content-Type": "application/json", Accept: "application/json" };
+var serviceRoot = 'http://services.odata.org/V4/(S(34wtn2c0hkuk5ekg0pjr513b))/TripPinServiceRW/';
+var headers = { 'Content-Type': 'application/json', Accept: 'application/json' };
 var newPerson = {
-    UserName:"lewisblack",
-    FirstName:"Lewis",
-    LastName:"Black",
+    UserName:'lewisblack',
+    FirstName:'Lewis',
+    LastName:'Black',
     Emails:[
-        "lewisblack@example.com"
+        'lewisblack@example.com'
     ],
     AddressInfo:[
         {
-            Address: "187 Suffolk Ln.",
+            Address: '187 Suffolk Ln.',
             City: {
-                CountryRegion: "United States",
-                Name: "Boise",
-                Region: "ID"
+                CountryRegion: 'United States',
+                Name: 'Boise',
+                Region: 'ID'
             }
         }
     ],
-    Gender: "Male"
+    Gender: 'Male'
 };
 var request = {
-    requestUri: serviceRoot + "People",
-    method: "POST",
+    requestUri: serviceRoot + 'People',
+    method: 'POST',
     headers: headers,
     data: newPerson
 };
- 
+
 odatajs.oData.request(
     request,
     function (data, response) {
         var createeRes = response;
- 
+
     },
     function (err) {
-        alert("Fail: " + err.Message);
+        alert('Fail: ' + err.Message);
     }
 );
 ```
 # Step 5: Relating resources
 ```js
-var serviceRoot = "http://services.odata.org/V4/(S(34wtn2c0hkuk5ekg0pjr513b))/TripPinServiceRW/";
-var headers = { "Content-Type": "application/json", Accept: "application/json" };
+var serviceRoot = 'http://services.odata.org/V4/(S(34wtn2c0hkuk5ekg0pjr513b))/TripPinServiceRW/';
+var headers = { 'Content-Type': 'application/json', Accept: 'application/json' };
 var relateBody = {
-    "@odata.id":"http://services.odata.org/V4/(S(34wtn2c0hkuk5ekg0pjr513b))/TripPinServiceRW/People('russellwhyte')/Trips(0)"
+    '@odata.id':'http://services.odata.org/V4/(S(34wtn2c0hkuk5ekg0pjr513b))/TripPinServiceRW/People(\'russellwhyte\')/Trips(0)'
 };
 var request = {
-    requestUri: serviceRoot + "People('lewisblack')/Trips/$ref",
-    method: "POST",
+    requestUri: serviceRoot + 'People(\'lewisblack\')/Trips/$ref',
+    method: 'POST',
     headers: headers,
     data: relateBody
 };
- 
+
 odatajs.oData.request(
     request,
     function (data, response) {
         var res = response;
- 
+
     },
     function (err) {
-        alert("Fail: " + err.Message);
+        alert('Fail: ' + err.Message);
     }
 );
 ```
 # Step 6: Invoking a function
 ```js
-var serviceRoot = "http://services.odata.org/V4/(S(34wtn2c0hkuk5ekg0pjr513b))/TripPinServiceRW/";
-var headers = { "Content-Type": "application/json", Accept: "application/json" };
+var serviceRoot = 'http://services.odata.org/V4/(S(34wtn2c0hkuk5ekg0pjr513b))/TripPinServiceRW/';
+var headers = { 'Content-Type': 'application/json', Accept: 'application/json' };
 var request = {
-    requestUri: serviceRoot + "People('russellwhyte')/Trips(0)/Microsoft.OData.SampleService.Models.TripPin.GetInvolvedPeople()",
-    method: "GET",
+    requestUri: serviceRoot + 'People(\'russellwhyte\')/Trips(0)/Microsoft.OData.SampleService.Models.TripPin.GetInvolvedPeople()',
+    method: 'GET',
     headers: headers,
     data: null
 };
- 
+
 odatajs.oData.request(
     request,
     function (data, response) {
         var involvedPeople = data.value;
- 
+
     },
     function (err) {
-        alert("Fail: " + err.Message);
+        alert('Fail: ' + err.Message);
     }
 );
 ```


### PR DESCRIPTION
on the odata.org double-quotes in js/node.js code are converted to single-quotes for some reason, which promotes `'russellwhyte'` to a syntax error:
![screen shot 2015-06-30 at 12 38 01 pm](https://cloud.githubusercontent.com/assets/9968388/8429153/42571e0e-1f25-11e5-94cb-7e874b1d62f9.png) ![screen shot 2015-06-30 at 12 38 14 pm](https://cloud.githubusercontent.com/assets/9968388/8429154/427e48b2-1f25-11e5-8477-d8538a64a842.png)

same with json-responses:
![screen shot 2015-06-30 at 12 42 07 pm](https://cloud.githubusercontent.com/assets/9968388/8429181/85583ed6-1f25-11e5-8e39-37221e39e23e.png)
